### PR TITLE
Fixed incorrect external symbol declaration

### DIFF
--- a/app/main.c
+++ b/app/main.c
@@ -38,7 +38,7 @@
 /************************** Variable Definitions *****************************/
 static int verbose_flag=0;
 char *filename;
-FILE *fp_out;
+extern FILE *fp_out;
 static int sample_interval=0;
 static int sample_window=1;
 char *temp;

--- a/src/platformstats.c
+++ b/src/platformstats.c
@@ -20,7 +20,7 @@
 
 #define MAX_FILENAME_LEN 500
 
-extern FILE *fp_out;
+FILE *fp_out;
 
 struct cpustat* stat0;
 struct cpustat* stat1;


### PR DESCRIPTION
Cause SOM-Dashboard failed to link libplatformstats.so